### PR TITLE
removing parenthesis causing int overflow

### DIFF
--- a/sqmr-1.1.0/sqmr.c
+++ b/sqmr-1.1.0/sqmr.c
@@ -193,7 +193,7 @@ benchmark (int msgsize, int iters)
 	{
 	  double msgs;
 
-	  msgs = (double) (win_size * num_nbors * num_cores * iters * 2);
+	  msgs = (double) win_size * num_nbors * num_cores * iters * 2;
 	  printf
 	    ("%8d %6d %12.2lf %10.2lf %12.2lf %10.2lf %12.2lf %10.2lf\n",
 	     msgsize, iters,  msgs / mean,


### PR DESCRIPTION
during combinations of high window size, iteration counts, and/or rank sizes, the number of messages
overflows when the operation is contained within parenthesis, causing erroneous benchmark results.
removing parenthesis properly casts to a double.